### PR TITLE
Remove nix-direnv option from direnv

### DIFF
--- a/users/tfo01/home-manager.nix
+++ b/users/tfo01/home-manager.nix
@@ -83,7 +83,6 @@ in {
 
   programs.direnv = {
     enable = true;
-    nix-direnv.enable = true;
     config = {
       whitelist = {
         exact = ["${config.home.homeDirectory}/.envrc"];

--- a/users/tomford/home-manager.nix
+++ b/users/tomford/home-manager.nix
@@ -78,7 +78,6 @@ in {
 
   programs.direnv = {
     enable = true;
-    nix-direnv.enable = true;
     config = {
       whitelist = {
         exact = ["${config.home.homeDirectory}/.envrc"];


### PR DESCRIPTION
Remove `nix-direnv.enable` from Home Manager direnv configurations to resolve LSP issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-16cd46e9-b259-4271-ae76-04bd364e318d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16cd46e9-b259-4271-ae76-04bd364e318d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

