### PR TITLE
Add git alias for local branch cleanup

### DIFF
--- a/users/tfo01/home-manager.nix
+++ b/users/tfo01/home-manager.nix
@@ -96,6 +96,7 @@ in {
     enable = true;
     aliases = {
       prettylog = "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative";
+      cleanup = "!git for-each-ref --format '%(refname:short) %(upstream)' refs/heads | awk '$2 == \"\" {print $1}' | xargs -r git branch -D";
     };
 
     includes = [

--- a/users/tomford/home-manager.nix
+++ b/users/tomford/home-manager.nix
@@ -99,6 +99,7 @@ in {
     };
     aliases = {
       prettylog = "log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative";
+      cleanup = "!git for-each-ref --format '%(refname:short) %(upstream)' refs/heads | awk '$2 == \"\" {print $1}' | xargs -r git branch -D";
     };
     extraConfig = {
       branch.autosetuprebase = "always";


### PR DESCRIPTION
Add `git cleanup` alias to home manager configs to delete local-only branches.

This alias uses `git for-each-ref` to identify branches that do not track any remote upstream, ensuring only truly local, unreferenced branches are removed, while leaving branches with an an upstream (even if not up-to-date) untouched.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b5c453e-9a10-433a-b389-f6dfbc75c21d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b5c453e-9a10-433a-b389-f6dfbc75c21d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

