### PR TITLE
Add ntfy and msgtom command for raspi notifications

### DIFF
--- a/users/tomford/home-manager.nix
+++ b/users/tomford/home-manager.nix
@@ -55,6 +55,10 @@
       tailscale = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
     };
 
+  msgtom = pkgs.writeShellScriptBin "msgtom" ''
+    curl -d "''${1:-no message}" http://localhost/tom-agent
+  '';
+
   jgts = pkgs.writeShellScriptBin "jgts" ''
     set -euo pipefail
 
@@ -123,8 +127,10 @@ in {
     ]
     ++ (lib.optionals isLinux [
       pkgs.cloudflared
+      pkgs.ntfy-sh
       pkgs.postgresql_18
       pkgs.tailscale
+      msgtom
     ]);
 
   home.sessionVariables = {

--- a/users/tomford/home-manager.nix
+++ b/users/tomford/home-manager.nix
@@ -56,7 +56,7 @@
     };
 
   msgtom = pkgs.writeShellScriptBin "msgtom" ''
-    curl -d "''${1:-no message}" http://localhost/tom-agent
+    curl -d "''${1:-no message}" http://localhost/ntfy
   '';
 
   jgts = pkgs.writeShellScriptBin "jgts" ''


### PR DESCRIPTION
- Add ntfy-sh package to Linux-only packages
- Add msgtom shell script to send notifications via local ntfy server

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added notification capabilities for Raspberry Pi by including the `ntfy-sh` package and creating a custom `msgtom` shell script. The script sends messages to a local ntfy server at `http://localhost/tom-agent` using curl, with a default message if none is provided. Both additions are Linux-only packages, properly scoped for the Raspberry Pi environment.

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minimal risk - straightforward package addition and simple notification script
- The changes are well-scoped to Linux-only packages and follow the existing pattern in the codebase. The `msgtom` script is simple and properly uses Nix string interpolation. Minor suggestion for error handling improvement, but not critical for functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| users/tomford/home-manager.nix | Added `ntfy-sh` package and `msgtom` notification script for Raspberry Pi notifications |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->